### PR TITLE
Escape injected end tags

### DIFF
--- a/lib/injectIntoMarkup.js
+++ b/lib/injectIntoMarkup.js
@@ -8,7 +8,8 @@
  * @param {?Array} scripts
  */
 function injectIntoMarkup(markup, data, scripts) {
-  var injected = '<script>window.__reactAsyncStatePacket=' + JSON.stringify(data) + '</script>';
+  var escapedJson = JSON.stringify(data).replace(/<\//g, '<\\/');
+  var injected = '<script>window.__reactAsyncStatePacket=' + escapedJson + '</script>';
 
   if (scripts) {
     injected += scripts.map(function(script) {

--- a/tests/injectIntoMarkup-server.js
+++ b/tests/injectIntoMarkup-server.js
@@ -31,4 +31,11 @@ describe('ReactAsync.injectIntoMarkup (server)', function() {
     assert.ok(injected.indexOf(markup) > -1);
     assert.ok(injected.indexOf('<script>window.__reactAsyncStatePacket={"foo":"bar"}</script>') > -1);
   });
+
+  it('escapes HTML end tags in JSON before injecting into markup', function() {
+    var data = {foo: '<script></script>'};
+    var markup = '<html><head></head><body>Escape test</body>';
+    var injected = ReactAsync.injectIntoMarkup(markup, data);
+    assert.ok(injected.indexOf('<script><\\/script>') > -1);
+  });
 });


### PR DESCRIPTION
This addresses the escaping issue reported in andreypopp/react-async#8 -- thanks for your help!

This solved my particular issue but I'd be happy to improve it if you have any suggestions.
