### PR TITLE
Avoiding setting an empty state (fallback to {})

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -63,7 +63,7 @@ var Mixin = {
     }
 
     if (this.isMounted()) {
-      this.setState(asyncState);
+      this.setState(asyncState || {});
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ var Mixin = {
 
     Fiber.current.__reactAsyncStatePacket[fingerprint] = storedAsyncState;
 
-    return asyncState;
+    return asyncState || {};
   }
 }
 

--- a/lib/prefetchAsyncState.js
+++ b/lib/prefetchAsyncState.js
@@ -24,7 +24,7 @@ function prefetchAsyncState(component, cb) {
       return cb(err);
     }
 
-    cb(null, cloneWithProps(component, {asyncState: asyncState}));
+    cb(null, cloneWithProps(component, {asyncState: asyncState || {}}));
   };
   var getInitialStateAsync = component.constructor.type.prototype.getInitialStateAsync;
   var promise = getInitialStateAsync.call(component, cloneCallback);


### PR DESCRIPTION
I just faced a problem where I could optionally send data to the component via props:

``` javascript
<MyComponent data={preloadedObject} />
```

Then I checked:

``` javascript
getInitialStateAsync: function() {
    if (this.props.data) return false;
    return new Controller().get(this.props._id);
}
```

Returning nothing would break the rendering. This PR solves it.
