### PR TITLE
Cancelling getInitialStateAsync if it returns false

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ var Mixin = {
 
       if (promise && typeof promise.then === 'function') {
         promise.then(cb.bind(cb, null), cb);
+      } else if (promise === false) {
+        cb(null);
       }
     }.bind(this));
     var asyncState = getInitialStateAsync().wait();


### PR DESCRIPTION
Related to #27.

My fault... I forgot to add this obvious check. Now, _getInitialStateAsync_ must return **Boolean(false)** to be cancelled. Cancelled means that It won't wait for the callback to be called.
