### PR TITLE
`type` fix for React v0.12.

### DIFF
--- a/lib/isAsyncComponent.js
+++ b/lib/isAsyncComponent.js
@@ -6,7 +6,7 @@
  * @param {ReactComponent} component
  */
 function isAsyncComponent(component) {
-  return typeof component.type.prototype.getInitialStateAsync === 'function';
+  return component.type.prototype && typeof component.type.prototype.getInitialStateAsync === 'function';
 }
 
 module.exports = isAsyncComponent;


### PR DESCRIPTION
On `React.DOM` components, `type` is a string rather than the class definition.

In that case, `isAsyncComponent` will fail as the `prototype` property is not defined.
