### PR TITLE
React 0.13 support.

### DIFF
--- a/lib/Preloaded.js
+++ b/lib/Preloaded.js
@@ -10,7 +10,7 @@ var isAsyncComponent    = require('./isAsyncComponent');
 var PreloaderMixin = {
 
   propTypes: {
-    children: React.PropTypes.component.isRequired,
+    children: React.PropTypes.element.isRequired,
     onAsyncStateFetched: React.PropTypes.func,
     onBeforeUpdate: React.PropTypes.func,
     preloader: React.PropTypes.element,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "browser": "browser.js",
   "peerDependencies": {
-    "react": "~0.12.0"
+    "react": ">=0.12.0 <0.14.0"
   },
   "devDependencies": {
     "browserify": "^6.1.0",


### PR DESCRIPTION
No big changes needed, but `React.PropTypes.component` moved from deprecated to removed.

This keeps the peerDependency broad. We know it works on both versions so I don't see any need to set `~0.13` specifically. I plan on setting the same React peerDependency on RRC.